### PR TITLE
Fix bug: svg element's className is not string.

### DIFF
--- a/src/Handler.js
+++ b/src/Handler.js
@@ -42,7 +42,7 @@ define(
                           || event.srcElement
                           || event.target;
 
-            return target && target.className.match(config.elementClassName)
+            return target && target.getAttribute("class").match(config.elementClassName)
         };
 
         var domHandlers = {


### PR DESCRIPTION
svg element's className is not string.

className -> getAttribute("class")
